### PR TITLE
explicitly specify encoding (utf-8) for JSON files

### DIFF
--- a/beta_code/beta_code.py
+++ b/beta_code/beta_code.py
@@ -5,10 +5,10 @@ import os
 import re
 import unicodedata
 
-with open(os.path.join(os.path.dirname(__file__), 'vendor/beta-code-json/beta_code_to_unicode.json')) as json_file:
+with open(os.path.join(os.path.dirname(__file__), 'vendor/beta-code-json/beta_code_to_unicode.json'), encoding='utf-8') as json_file:
   BETA_CODE_TO_UNICODE_MAP = json.load(json_file)
 
-with open(os.path.join(os.path.dirname(__file__), 'vendor/beta-code-json/unicode_to_beta_code.json')) as json_file:
+with open(os.path.join(os.path.dirname(__file__), 'vendor/beta-code-json/unicode_to_beta_code.json'), encoding='utf-8') as json_file:
   UNICODE_TO_BETA_CODE_MAP = json.load(json_file)
 
 def greek_to_beta_code(greek, custom_map=None):


### PR DESCRIPTION
Importing `beta_code` in an Anaconda environment running on a Windows system results in the following error:

```python
UnicodeDecodeError                        Traceback (most recent call last)
Cell In[1], line 1
----> 1 import beta_code

File ~\anaconda3\envs\CLTK-env\lib\site-packages\beta_code\__init__.py:1
----> 1 from .beta_code import greek_to_beta_code, beta_code_to_greek
      3 name = "beta_code"
...
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 54: character maps to <undefined>
```

This error occurs because the JSON files are loaded using the default Windows system encoding (`cp1252`) instead of UTF-8. Although the JSON data files are correctly encoded in UTF-8, the code does not explicitly specify this encoding when reading the files. 

To resolve this issue, modify the `beta_code.py` file to explicitly declare UTF-8 encoding when opening the JSON files. This change ensures the library loads correctly and prevents the `UnicodeDecodeError`.